### PR TITLE
CreateStoreRequestTest 개선, StoreService 유닛 테스트 추가

### DIFF
--- a/app/src/main/java/com/foodlab/foodReservation/store/dto/request/CreateStoreRequest.java
+++ b/app/src/main/java/com/foodlab/foodReservation/store/dto/request/CreateStoreRequest.java
@@ -14,10 +14,11 @@ public class CreateStoreRequest {
     public static final String addressBlankErrorMsg = "상점 주소는 꼭 입력해야 합니다.";
 
     public static final String longitudeRangeErrorMsg = "경도의 값은 -180도 이상, 180도 이하여야 합니다.";
-    public static final String longitudeNullErrorMsg = "경도의 값은 널이 될 수 없습니다.";
+    public static final String longitudeNullErrorMsg = "경도의 값은 꼭 입력해야 합니다.";
 
     public static final String latitudeRangeErrorMsg = "위도의 값은 -90도 이상, 90도 이하여야 합니다.";
-    public static final String latitudeNullErrorMsg = "위도의 값은 널이 될 수 없습니다.";
+    public static final String latitudeNullErrorMsg = "위도의 값은 꼭 입력해야 합니다.";
+
     public static final String zipCodeBlankErrorMsg = "상점 우편번호는 꼭 입력해야 합니다.";
 
 
@@ -44,5 +45,3 @@ public class CreateStoreRequest {
     private String zipCode;
 
 }
-
-

--- a/app/src/main/java/com/foodlab/foodReservation/store/service/StoreService.java
+++ b/app/src/main/java/com/foodlab/foodReservation/store/service/StoreService.java
@@ -37,6 +37,7 @@ public class StoreService {
         return new CreateStoreResponse(savedStore.getId());
     }
 
+    @Transactional
     public void deleteStore(Long storeId) {
         Store store = storeRepository.findById(storeId).orElseThrow(
                 () -> new IllegalArgumentException("존재하지 않는 음식점입니다."));

--- a/app/src/test/java/com/foodlab/foodReservation/store/dto/request/CreateStoreRequestTest.java
+++ b/app/src/test/java/com/foodlab/foodReservation/store/dto/request/CreateStoreRequestTest.java
@@ -1,33 +1,52 @@
 package com.foodlab.foodReservation.store.dto.request;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.*;
 
 import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
 import javax.validation.Validator;
 
 import java.util.Set;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@SpringBootTest
 class CreateStoreRequestTest {
 
-    @Autowired
-    private Validator validator;
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
 
-    @Test
-    void blankNameShouldViolate() {
-        // given
-        String name = "";
-
+    CreateStoreRequest getValidCreateStoreRequest() {
         CreateStoreRequest request = new CreateStoreRequest();
-        request.setName(name);
+        request.setName("Son Heung Min");
         request.setAddress("서울시");
         request.setLongitude(12.0);
         request.setLatitude(12.0);
         request.setZipCode("123-456");
+
+        return request;
+    }
+
+    @Test
+    void validDtoShouldBeValid() {
+        // given
+        CreateStoreRequest request = getValidCreateStoreRequest();
+
+        // when
+        Set<ConstraintViolation<CreateStoreRequest>> validate = validator.validate(request);
+
+        // then
+        assertEquals(0, validate.size());
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"  ", "   ", "\t", "\n"})
+    void blankNameShouldViolate(String name) {
+        // given
+        CreateStoreRequest request = getValidCreateStoreRequest();
+        request.setName(name);
 
         // when
         Set<ConstraintViolation<CreateStoreRequest>> validate = validator.validate(request);
@@ -37,84 +56,155 @@ class CreateStoreRequestTest {
         assertEquals(CreateStoreRequest.nameBlankErrorMsg, validate.stream().iterator().next().getMessage());
     }
 
-    @Test
-    void nullNameShouldViolate() {
+    @ParameterizedTest
+    @ValueSource(strings = {"Kim", "Lee", "Park", "random name"})
+    void notBlankNameShouldBeValid(String name) {
         // given
-        String name = null;
-
-        CreateStoreRequest request = new CreateStoreRequest();
+        CreateStoreRequest request = getValidCreateStoreRequest();
         request.setName(name);
-        request.setAddress("서울시");
-        request.setLongitude(12.0);
-        request.setLatitude(12.0);
-        request.setZipCode("123-456");
 
         // when
         Set<ConstraintViolation<CreateStoreRequest>> validate = validator.validate(request);
 
         // then
-        assertEquals(1, validate.size());
-        assertEquals(CreateStoreRequest.nameBlankErrorMsg, validate.stream().iterator().next().getMessage());
+        assertEquals(0, validate.size());
     }
 
-    @Test
-    void longitudeMoreThan180ShouldViolate() {
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"  ", "   ", "\t", "\n"})
+    void blankAddressShouldViolate(String address) {
         // given
-        double longitude = 180.1;
-
-        CreateStoreRequest request = new CreateStoreRequest();
-        request.setName("Kim");
-        request.setAddress("서울시");
-        request.setLongitude(longitude);
-        request.setLatitude(12.0);
-        request.setZipCode("123-456");
+        CreateStoreRequest request = getValidCreateStoreRequest();
+        request.setAddress(address);
 
         // when
         Set<ConstraintViolation<CreateStoreRequest>> validate = validator.validate(request);
 
         // then
         assertEquals(1, validate.size());
-        assertEquals(CreateStoreRequest.longitudeRangeErrorMsg, validate.stream().iterator().next().getMessage());
+        assertEquals(CreateStoreRequest.addressBlankErrorMsg, validate.stream().iterator().next().getMessage());
     }
 
-    @Test
-    void longitudeLessThanMinus180ShouldViolate() {
+    @ParameterizedTest
+    @ValueSource(strings = {"Seoul ABC Street", "Taipei", "Somewhere in the world"})
+    void notBlankAddressShouldBeValid(String address) {
         // given
-        double longitude = -180.1;
-
-        CreateStoreRequest request = new CreateStoreRequest();
-        request.setName("Kim");
-        request.setAddress("서울시");
-        request.setLongitude(longitude);
-        request.setLatitude(12.0);
-        request.setZipCode("123-456");
+        CreateStoreRequest request = getValidCreateStoreRequest();
+        request.setAddress(address);
 
         // when
         Set<ConstraintViolation<CreateStoreRequest>> validate = validator.validate(request);
 
         // then
-        assertEquals(1, validate.size());
-        assertEquals(CreateStoreRequest.longitudeRangeErrorMsg, validate.stream().iterator().next().getMessage());
+        assertEquals(0, validate.size());
     }
 
-    @Test
-    void longitudeNullShouldViolate() {
+    @ParameterizedTest
+    @MethodSource("longitudeTestArgumentsProvider")
+    void longitudeOutSidePlusMinus180ShouldViolate(Double longitude, String errorMsg) {
         // given
-        Double longitude = null;
-
-        CreateStoreRequest request = new CreateStoreRequest();
-        request.setName("Kim");
-        request.setAddress("서울시");
+        CreateStoreRequest request = getValidCreateStoreRequest();
         request.setLongitude(longitude);
-        request.setLatitude(12.0);
-        request.setZipCode("123-456");
 
         // when
         Set<ConstraintViolation<CreateStoreRequest>> validate = validator.validate(request);
 
         // then
         assertEquals(1, validate.size());
-        assertEquals(CreateStoreRequest.longitudeNullErrorMsg, validate.stream().iterator().next().getMessage());
+        assertEquals(errorMsg, validate.stream().iterator().next().getMessage());
     }
 
+    static Stream<Arguments> longitudeTestArgumentsProvider() {
+        return Stream.of(
+                Arguments.of(null, CreateStoreRequest.longitudeNullErrorMsg),
+                Arguments.of(180.1, CreateStoreRequest.longitudeRangeErrorMsg),
+                Arguments.of(-180.1, CreateStoreRequest.longitudeRangeErrorMsg),
+                Arguments.of(190.0, CreateStoreRequest.longitudeRangeErrorMsg),
+                Arguments.of(-190.0, CreateStoreRequest.longitudeRangeErrorMsg)
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(doubles = {180.0, 92.4, 0, -103.2, -180.0})
+    void longitudeWithinPlusMinus180ShouldBeValid(Double longitude) {
+        // given
+        CreateStoreRequest request = getValidCreateStoreRequest();
+        request.setLongitude(longitude);
+
+        // when
+        Set<ConstraintViolation<CreateStoreRequest>> validate = validator.validate(request);
+
+        // then
+        assertEquals(0, validate.size());
+    }
+
+    @ParameterizedTest
+    @MethodSource("latitudeTestArgumentsProvider")
+    void latitudeOutSidePlusMinus90ShouldViolate(Double latitude, String errorMsg) {
+        // given
+        CreateStoreRequest request = getValidCreateStoreRequest();
+        request.setLatitude(latitude);
+
+        // when
+        Set<ConstraintViolation<CreateStoreRequest>> validate = validator.validate(request);
+
+        // then
+        assertEquals(1, validate.size());
+        assertEquals(errorMsg, validate.stream().iterator().next().getMessage());
+    }
+
+    static Stream<Arguments> latitudeTestArgumentsProvider() {
+        return Stream.of(
+                Arguments.of(null, CreateStoreRequest.latitudeNullErrorMsg),
+                Arguments.of(90.1, CreateStoreRequest.latitudeRangeErrorMsg),
+                Arguments.of(-90.1, CreateStoreRequest.latitudeRangeErrorMsg),
+                Arguments.of(100.0, CreateStoreRequest.latitudeRangeErrorMsg),
+                Arguments.of(-100.0, CreateStoreRequest.latitudeRangeErrorMsg)
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(doubles = {90.0, 30.9, 0, -47.8, -90.0})
+    void latitudeWithinPlusMinus90ShouldBeValid(Double latitude) {
+        // given
+        CreateStoreRequest request = getValidCreateStoreRequest();
+        request.setLatitude(latitude);
+
+        // when
+        Set<ConstraintViolation<CreateStoreRequest>> validate = validator.validate(request);
+
+        // then
+        assertEquals(0, validate.size());
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"  ", "   ", "\t", "\n"})
+    void blankZipCodeShouldViolate(String zipCode) {
+        // given
+        CreateStoreRequest request = getValidCreateStoreRequest();
+        request.setZipCode(zipCode);
+
+        // when
+        Set<ConstraintViolation<CreateStoreRequest>> validate = validator.validate(request);
+
+        // then
+        assertEquals(1, validate.size());
+        assertEquals(CreateStoreRequest.zipCodeBlankErrorMsg, validate.stream().iterator().next().getMessage());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"0923-234", "3891123", "A"})
+    void notBlankZipCodeShouldViolate(String zipCode) {
+        // given
+        CreateStoreRequest request = getValidCreateStoreRequest();
+        request.setZipCode(zipCode);
+
+        // when
+        Set<ConstraintViolation<CreateStoreRequest>> validate = validator.validate(request);
+
+        // then
+        assertEquals(0, validate.size());
+    }
 }

--- a/app/src/test/java/com/foodlab/foodReservation/store/service/StoreServiceTest.java
+++ b/app/src/test/java/com/foodlab/foodReservation/store/service/StoreServiceTest.java
@@ -1,0 +1,123 @@
+package com.foodlab.foodReservation.store.service;
+
+import com.foodlab.foodReservation.seller.entity.Seller;
+import com.foodlab.foodReservation.seller.repository.SellerRepository;
+import com.foodlab.foodReservation.store.dto.request.CreateStoreRequest;
+import com.foodlab.foodReservation.store.dto.response.CreateStoreResponse;
+import com.foodlab.foodReservation.store.entity.Store;
+import com.foodlab.foodReservation.store.repository.StoreRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class StoreServiceTest {
+
+    @Mock
+    StoreRepository storeRepository;
+
+    @Mock
+    SellerRepository sellerRepository;
+
+    @InjectMocks
+    StoreService storeService;
+
+    CreateStoreRequest getCreateStoreRequest() {
+        CreateStoreRequest request = new CreateStoreRequest();
+        request.setSellerId(1);
+        request.setName("Son");
+        request.setAddress("Seoul");
+        request.setLongitude(100.0);
+        request.setLatitude(90.0);
+        request.setZipCode("123");
+        return request;
+    }
+
+    @DisplayName("상점 생성 요청이 들어왔을 때, 판매자가 존재하면 상점이 생성되어야 합니다.")
+    @Test
+    void createStoreShouldCreateStoreIfSellerFound() {
+        // given
+        CreateStoreRequest request = getCreateStoreRequest();
+        Seller seller = new Seller();
+        Store store = new Store();
+
+        Long storeId = 423L;
+        ReflectionTestUtils.setField(store, "id", storeId);
+
+        when(sellerRepository.findById(request.getSellerId()))
+                .thenReturn(Optional.of(seller));   // seller found
+
+        when(storeRepository.save(any(Store.class)))
+                .thenReturn(store);
+
+        // when
+        CreateStoreResponse response = storeService.createStore(request);
+
+        // then
+        assertEquals(storeId, response.getStoreId());
+
+        // verify
+        verify(sellerRepository).findById(request.getSellerId());
+        verify(storeRepository).save(any(Store.class));
+    }
+
+    @DisplayName("상점 생성 요청이 들어왔을 때, 판매자가 존재하지 않으면 상점 만들기 요청은 예외를 발생시켜야 합니다.")
+    @Test
+    void createStoreShouldThrowIfSellerNotFound() {
+        // given
+        CreateStoreRequest request = getCreateStoreRequest();
+
+        when(sellerRepository.findById(request.getSellerId()))
+                .thenReturn(Optional.empty());   // seller not found
+
+        // then
+        assertThrows(IllegalArgumentException.class, () -> storeService.createStore(request));
+
+        verify(sellerRepository).findById(request.getSellerId());
+        verifyNoInteractions(storeRepository);
+    }
+
+    @DisplayName("상점 삭제 요청이 들어왔을 때, 해당 상점이 존재하면 상점을 삭제해야 합니다.")
+    @Test
+    void deleteStoreShouldDeleteStoreIfStoreFound() {
+        // given
+        Store store = new Store();
+        Store spyStore = spy(store);
+
+        Long storeId = 123L;
+
+        when(storeRepository.findById(storeId))
+                .thenReturn(Optional.of(spyStore));
+
+        // when
+        storeService.deleteStore(storeId);
+
+        // then
+        verify(storeRepository).findById(storeId);
+        verify(spyStore).delete();
+    }
+
+    @DisplayName("상점 삭제 요청이 들어왔을 때, 해당 상점이 존재하지 않으면 예외를 발생시켜야 합니다.")
+    @Test
+    void deleteStoreShouldThrowIfStoreNotFound() {
+        // given
+        when(storeRepository.findById(anyLong()))
+                .thenReturn(Optional.empty());
+
+        // then
+        assertThrows(IllegalArgumentException.class, () -> storeService.deleteStore(214L));
+    }
+
+
+}


### PR DESCRIPTION
1. CreateStoreRequest를 좀 더 개선하였습니다.
- Parameterized 테스트로 변경
- happy path 테스트 추가
- 기존에 Spring 컨테이너에에 의해 주입되었던 Validator를 직접 초기화 하는 방식으로 변경하여, @SpringBootTest 어노테이션 없이 테스트 실행되도록 변경 (테스트 속도 증가)

2. StoreService 유닛 테스트를 추가하였습니다.
- createStore, deleteStore에 대한 테스트 작성
- Mockito를 이용여 repository를 mocking