### PR TITLE
[Fix] 컨트롤러 메서드 리턴 타입 변경

### DIFF
--- a/app/src/main/java/com/foodlab/foodReservation/item/controller/ItemController.java
+++ b/app/src/main/java/com/foodlab/foodReservation/item/controller/ItemController.java
@@ -1,10 +1,9 @@
 package com.foodlab.foodReservation.item.controller;
 
 import com.foodlab.foodReservation.item.dto.request.UpdateItemRequest;
+import com.foodlab.foodReservation.item.dto.response.UpdateItemResponse;
 import com.foodlab.foodReservation.item.service.ItemService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -19,8 +18,7 @@ public class ItemController {
     private final ItemService itemService;
 
     @PutMapping("/items/{itemId}")
-    public ResponseEntity<Void> updateItem(@PathVariable("itemId") Long itemId, @RequestBody @Valid UpdateItemRequest updateItemRequest) {
-        itemService.updateItem(itemId, updateItemRequest);
-        return new ResponseEntity<>(HttpStatus.OK);
+    public UpdateItemResponse updateItem(@PathVariable("itemId") Long itemId, @RequestBody @Valid UpdateItemRequest updateItemRequest) {
+        return itemService.updateItem(itemId, updateItemRequest);
     }
 }

--- a/app/src/main/java/com/foodlab/foodReservation/item/dto/response/UpdateItemResponse.java
+++ b/app/src/main/java/com/foodlab/foodReservation/item/dto/response/UpdateItemResponse.java
@@ -1,0 +1,22 @@
+package com.foodlab.foodReservation.item.dto.response;
+
+import com.foodlab.foodReservation.item.entity.Item;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class UpdateItemResponse {
+
+    private final String name;
+    private final Integer price;
+
+    public static UpdateItemResponse of(Item item) {
+        return UpdateItemResponse.builder()
+                .name(item.getName())
+                .price(item.getPrice())
+                .build();
+    }
+}

--- a/app/src/main/java/com/foodlab/foodReservation/item/service/ItemService.java
+++ b/app/src/main/java/com/foodlab/foodReservation/item/service/ItemService.java
@@ -1,6 +1,7 @@
 package com.foodlab.foodReservation.item.service;
 
 import com.foodlab.foodReservation.item.dto.request.UpdateItemRequest;
+import com.foodlab.foodReservation.item.dto.response.UpdateItemResponse;
 import com.foodlab.foodReservation.item.entity.Item;
 import com.foodlab.foodReservation.item.repository.ItemRepository;
 import lombok.RequiredArgsConstructor;
@@ -14,9 +15,10 @@ public class ItemService {
     private final ItemRepository itemRepository;
 
     @Transactional
-    public void updateItem(Long itemId, UpdateItemRequest updateItemRequest) {
+    public UpdateItemResponse updateItem(Long itemId, UpdateItemRequest updateItemRequest) {
         Item item = itemRepository.findById(itemId).orElseThrow(
                 () -> new IllegalArgumentException("존재하지 않는 메뉴입니다."));
         item.updateItem(updateItemRequest.getName(), updateItemRequest.getPrice());
+        return UpdateItemResponse.of(item);
     }
 }

--- a/app/src/main/java/com/foodlab/foodReservation/store/controller/StoreController.java
+++ b/app/src/main/java/com/foodlab/foodReservation/store/controller/StoreController.java
@@ -4,6 +4,7 @@ package com.foodlab.foodReservation.store.controller;
 import com.foodlab.foodReservation.store.dto.request.CreateStoreRequest;
 import com.foodlab.foodReservation.store.dto.request.UpdateStoreRequest;
 import com.foodlab.foodReservation.store.dto.response.CreateStoreResponse;
+import com.foodlab.foodReservation.store.dto.response.DeleteStoreResponse;
 import com.foodlab.foodReservation.store.dto.response.UpdateStoreResponse;
 import com.foodlab.foodReservation.store.service.StoreService;
 import lombok.RequiredArgsConstructor;
@@ -25,9 +26,8 @@ public class StoreController {
     private final StoreService storeService;
 
     @PostMapping("/stores")
-    public ResponseEntity<CreateStoreResponse> createStore(@RequestBody @Valid CreateStoreRequest createStoreDto) {
-        CreateStoreResponse response = storeService.createStore(createStoreDto);
-        return new ResponseEntity<>(response, HttpStatus.CREATED);
+    public CreateStoreResponse createStore(@RequestBody @Valid CreateStoreRequest createStoreDto) {
+        return storeService.createStore(createStoreDto);
     }
 
     @PutMapping("/store/{storeId}")
@@ -37,9 +37,8 @@ public class StoreController {
     }
 
     @DeleteMapping("/store/{storeId}")
-    public ResponseEntity<Void> deleteStore(@PathVariable Long storeId) {
-        storeService.deleteStore(storeId);
-        return new ResponseEntity<>(HttpStatus.OK);
+    public DeleteStoreResponse deleteStore(@PathVariable Long storeId) {
+        return storeService.deleteStore(storeId);
     }
 
 }

--- a/app/src/main/java/com/foodlab/foodReservation/store/dto/response/DeleteStoreResponse.java
+++ b/app/src/main/java/com/foodlab/foodReservation/store/dto/response/DeleteStoreResponse.java
@@ -1,0 +1,13 @@
+package com.foodlab.foodReservation.store.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class DeleteStoreResponse {
+
+    private final Long storeId;
+
+    public DeleteStoreResponse(Long storeId) {
+        this.storeId = storeId;
+    }
+}

--- a/app/src/main/java/com/foodlab/foodReservation/store/service/StoreService.java
+++ b/app/src/main/java/com/foodlab/foodReservation/store/service/StoreService.java
@@ -6,6 +6,7 @@ import com.foodlab.foodReservation.seller.repository.SellerRepository;
 import com.foodlab.foodReservation.store.dto.request.CreateStoreRequest;
 import com.foodlab.foodReservation.store.dto.request.UpdateStoreRequest;
 import com.foodlab.foodReservation.store.dto.response.CreateStoreResponse;
+import com.foodlab.foodReservation.store.dto.response.DeleteStoreResponse;
 import com.foodlab.foodReservation.store.dto.response.StoreDetailResponse;
 import com.foodlab.foodReservation.store.dto.response.UpdateStoreResponse;
 import com.foodlab.foodReservation.store.entity.Store;
@@ -51,10 +52,11 @@ public class StoreService {
     }
 
     @Transactional
-    public void deleteStore(Long storeId) {
+    public DeleteStoreResponse deleteStore(Long storeId) {
         Store store = storeRepository.findById(storeId).orElseThrow(
                 () -> new IllegalArgumentException("존재하지 않는 음식점입니다."));
         store.delete();
+        return new DeleteStoreResponse(storeId);
     }
 
     public StoreDetailResponse getStore(Long storeId) {
@@ -63,4 +65,3 @@ public class StoreService {
     }
 
 }
-

--- a/app/src/test/java/com/foodlab/foodReservation/item/service/ItemServiceTest.java
+++ b/app/src/test/java/com/foodlab/foodReservation/item/service/ItemServiceTest.java
@@ -1,6 +1,7 @@
 package com.foodlab.foodReservation.item.service;
 
 import com.foodlab.foodReservation.item.dto.request.UpdateItemRequest;
+import com.foodlab.foodReservation.item.dto.response.UpdateItemResponse;
 import com.foodlab.foodReservation.item.entity.Item;
 import com.foodlab.foodReservation.item.repository.ItemRepository;
 import com.foodlab.foodReservation.store.entity.Store;
@@ -25,13 +26,6 @@ class ItemServiceTest {
     @InjectMocks
     ItemService itemService;
 
-    UpdateItemRequest getValidUpdateItemRequest() {
-        return UpdateItemRequest.builder()
-                .name("누구나 좋아하는 하와이안 피자")
-                .price(11000)
-                .build();
-    }
-
     @DisplayName("메뉴 수정 요청이 들어왔을 때, 메뉴가 존재하면 메뉴가 수정되어야 합니다.")
     @Test
     void updateItemShouldUpdateItemWhenItemFound() {
@@ -41,14 +35,19 @@ class ItemServiceTest {
 
         when(itemRepository.findById(123L)).thenReturn(Optional.of(item));
 
-        UpdateItemRequest request = getValidUpdateItemRequest();
+        UpdateItemRequest request = UpdateItemRequest.builder()
+                .name("누구나 좋아하는 하와이안 피자")
+                .price(11000)
+                .build();
 
         // when
-        itemService.updateItem(123L, request);
+        UpdateItemResponse response = itemService.updateItem(123L, request);
 
         // then
         assertEquals("누구나 좋아하는 하와이안 피자", item.getName());
+        assertEquals("누구나 좋아하는 하와이안 피자", response.getName());
         assertEquals(11000, item.getPrice());
+        assertEquals(11000, response.getPrice());
 
         verify(itemRepository).findById(123L);
 
@@ -61,7 +60,10 @@ class ItemServiceTest {
         // given
         when(itemRepository.findById(123L)).thenReturn(Optional.empty());
 
-        UpdateItemRequest request = getValidUpdateItemRequest();
+        UpdateItemRequest request = UpdateItemRequest.builder()
+                .name("누구나 좋아하는 하와이안 피자")
+                .price(11000)
+                .build();
 
         // then
         assertThrows(IllegalArgumentException.class, () -> itemService.updateItem(123L, request));


### PR DESCRIPTION
1. 컨트롤러 메서드의 리턴 타입을 ResponseEntity에서 DTO로 변경 하였습니다. (Generic 한 리턴 타입은 정해지는대로 추후 적용할 예정입니다.)
- 적용된 메서드
  - StoreController.createStore
  - StoreController.deleteStore
  - ItemController.updateItem

2. 메서드 변경에 맞춰 DTO를 추가하였습니다.
- UpdateItemResponse DTO 추가 (Entity -> DTO 변경은 일단 factory 메서드로 구현하였습니다. 추후 MapStruct로 변경될 수 있습니다.)

3. 변경된 사항에 맞춰 테스트 코드도 일부 수정하였습니다.
- ItemServiceTest