### PR TITLE
[CD] docker image build, push 수행 workflow 추가

### DIFF
--- a/.github/workflows/image-build-and-push.yml
+++ b/.github/workflows/image-build-and-push.yml
@@ -1,0 +1,49 @@
+name: Image build and push
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'document/**'
+  workflow_dispatch:
+
+env:
+  DOCKERHUB_USER_NAME: oldrabbit736
+  IMAGE_NAME: oldrabbit736/food-reservation-app:0.0.${{ github.run_number }}
+
+jobs:
+  build-push-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@v1
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
+      - name: Build
+        run: ./gradlew build --scan
+
+      - name: Build container image
+        run: docker build app/ -t ${{ env.IMAGE_NAME }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ env.DOCKERHUB_USER_NAME }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+
+      - name: Push to container registry
+        run: docker push ${{ env.IMAGE_NAME }}
+
+      # TODO:
+      #- name: Deploy to production server

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 name: Test
 
-on: [pull_request]
+on:
+  pull_request:
+    paths-ignore:
+      - 'document/**'
 
 jobs:
   run-tests:
@@ -20,5 +23,5 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
 
-      - name: Execute Gradle check task
+      - name: Check
         run: ./gradlew check --scan

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,9 @@
-name: Integration Test
+name: Test
+
 on: [pull_request]
+
 jobs:
-  integration-test:
+  run-tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -18,5 +20,5 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
 
-      - name: Execute Gradle Integration Test
-        run: ./gradlew integrationTest --scan
+      - name: Execute Gradle check task
+        run: ./gradlew check --scan

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,0 +1,7 @@
+FROM eclipse-temurin:11.0.16.1_1-jre
+
+WORKDIR /app
+
+COPY build/libs/*.jar app.jar
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,6 +23,14 @@ dependencies {
     testRuntimeOnly 'com.h2database:h2'
 }
 
+/*
+- plain jar 파일 생성 해제
+- 도커 이미지에 복사될 jar 파일 외의 jar(plain jar) 생성 해제
+ */
+jar {
+    enabled = false
+}
+
 tasks.named('test') {
     useJUnitPlatform()
 


### PR DESCRIPTION
docker image build, push를 수행하는 workflow를 추가하였습니다.
프로젝트는 전체적으로 다음의 2가지 workflow로 구성됩니다.

1. "test" workflow
- pull request 발생 시 발동합니다.
- gradle check task를 실행하여, unit test, integration test 모두 실행합니다.
- 따라서 PR에 대한 검토자가 test 결과를 참조할 수 있습니다.

2. "build push deploy" workflow
- PR이 받아들여졌을 때 발동합니다.
- 기술적으로 보자면, main branch에 push가 발생하였을 때 발동합니다. 즉, PR이 받아들여져 main 브랜치에 merge가 되면 이 workflow가 발동하게 됩니다.
- 프로젝트 빌드, docker image build, docker hub에 docker image 업로드를 실행합니다.
- server 배포는 아직 작성되지 않았습니다. (TODO)

3. 특이 사항
- 일단 배포 registry는 Docker Hub의 제 개인 계정의 공개 repository로 하였으며, docker image 이름은 "oldrabbit736/food-reservation-app" 입니다.
