### PR TITLE
[INFRA] terraform을 이용한 NCP 인프라 리소스 설정

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@
       * IDE 실행 옵션을 다음과 같이 세팅한 후 앱을 실행시킵니다.
         * spring.active.profile=dev
         * JEP=...
-         
+
+## 인프라 설정 방법
+[링크](./infra/README.md)
 
 ## API Schema
 

--- a/infra/.gitignore
+++ b/infra/.gitignore
@@ -1,0 +1,37 @@
+# 아래의 terraform gitignore 설정은 아래 링크 내용을 그대로 복사한 내용임.
+# https://github.com/github/gitignore/blob/main/Terraform.gitignore
+
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -1,6 +1,25 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.1.1"
+  hashes = [
+    "h1:Pctug/s/2Hg5FJqjYcTM0kPyx3AoYK1MpRWO0T9V2ns=",
+    "zh:063466f41f1d9fd0dd93722840c1314f046d8760b1812fa67c34de0afcba5597",
+    "zh:08c058e367de6debdad35fc24d97131c7cf75103baec8279aba3506a08b53faf",
+    "zh:73ce6dff935150d6ddc6ac4a10071e02647d10175c173cfe5dca81f3d13d8afe",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8fdd792a626413502e68c195f2097352bdc6a0df694f7df350ed784741eb587e",
+    "zh:976bbaf268cb497400fd5b3c774d218f3933271864345f18deebe4dcbfcd6afa",
+    "zh:b21b78ca581f98f4cdb7a366b03ae9db23a73dfa7df12c533d7c19b68e9e72e5",
+    "zh:b7fc0c1615dbdb1d6fd4abb9c7dc7da286631f7ca2299fb9cd4664258ccfbff4",
+    "zh:d1efc942b2c44345e0c29bc976594cb7278c38cfb8897b344669eafbc3cddf46",
+    "zh:e356c245b3cd9d4789bab010893566acace682d7db877e52d40fc4ca34a50924",
+    "zh:ea98802ba92fcfa8cf12cbce2e9e7ebe999afbf8ed47fa45fc847a098d89468b",
+    "zh:eff8872458806499889f6927b5d954560f3d74bf20b6043409edf94d26cd906f",
+  ]
+}
+
 provider "registry.terraform.io/navercloudplatform/ncloud" {
   version = "2.3.0"
   hashes = [

--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/navercloudplatform/ncloud" {
+  version = "2.3.0"
+  hashes = [
+    "h1:lTXdf/raJuNSluvgJ2peeBWpJpaseJdLHdyGmjZnkG0=",
+    "zh:144ce1ba3dab7f42fe6a1d11269682cb8a0317119a314cad8b66af08fdc3a692",
+    "zh:20227ec45664a72223f0c817a0c4d73db8247cce78edd8284378b802bfee579f",
+    "zh:20361e88fc71de12214224eaaab3e9e28950418114e137768aeba2a62b1e8cfe",
+    "zh:27245ea943deab9f458f32d26008673f4bb75921f2edf5a1df1f7f504c2fa254",
+    "zh:34909b4be3f4e80850e052658dd0f8e41d135fbde0185180dc3bf7e454cdcf3b",
+    "zh:3940b7332c0fd6c1843762b4737abdc142a3bbf5eefbb89b70b1c851145a64b4",
+    "zh:5c4bfc96a1e5a9a2bb54be85cc52553e27f239dfbd83e4298630891c0ea0008a",
+    "zh:aa14bd7c01b614e5f287e98919667af1475188219acb6575c92c719b1688bb9d",
+    "zh:adcd7694d73e009f2d267fd2b1998144745844ffc1be259522318202c1ab9b04",
+    "zh:c43a46c4134cd119fd04adaacab9918725a5dad3e49c6f8fc7bf832cbd050051",
+    "zh:c599051864145c5e306f56add370299a603b1af4c2f104020efb7b16d07383d2",
+    "zh:dc8010aee804cbcd5a85f77bb21f1a2aa5ddd9521e4a0cb99a60bbb6998dd50e",
+    "zh:efebbbf03ac8eff60f49ca2bc29e433aaae0f6c6d4c0dbf3ac1e1be1bca8f224",
+  ]
+}

--- a/infra/README.md
+++ b/infra/README.md
@@ -51,11 +51,11 @@ Terraform Cloud에 프로젝트의 infra 구성 결과(.tfstate 파일)를 저�
 - NCP console에서 생성된 리소스를 확인합니다.
 - Terraform cloud에서 지정한 organization, food-reservation workspace에 리소스 구성 결과가 저장되어 있는지 확인합니다.
 
-## Step 5 - 서버에 ssh 접속, 초기화
-생성된 public ip를 통해 서버에 ssh 접속 확인합니다.
+## Step 5 (optional) - 서버에 ssh 접속
+필요시 생성된 public ip를 통해 서버에 ssh 접속 확인합니다.
 - ssh 접속합니다.
   ```shell
   $ ssh root@<public ip> -p 22
   ```
   - 필요한 public ip, root password는 food-reservation workspace의 "States"에서 확인할 수 있습니다.
-- infra/server-scripts 안의 스크립트들을 실행시켜서 초기화 시켜줍니다.
+- 필요한 소프트웨어가 설치되었는지 확인합니다. (docker 등)

--- a/infra/README.md
+++ b/infra/README.md
@@ -23,11 +23,11 @@ Terraform Cloud에 프로젝트의 infra 구성 결과(.tfstate 파일)를 저�
   - ncp_secret_key
     - category: Terraform variable
     - key: ncp_secret_key
-    - value: NCP의 Access Key ID 값
+    - value: NCP의 Secret Key ID 값
   - ncp_access_key
     - category: Terraform variable
     - key: ncp_access_key
-    - value: NCP의 Secret Key 값
+    - value: NCP의 Access Key 값
   - 참고: "Sensitive" 란을 체크하면 웹 페이지에서 값을 안 보이도록 할 수 있기에 설정하는 게 보안에 더 좋습니다.
 
 ## Step 4 - 인프라 생성

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,61 @@
+# Infra 설정 방법
+이 프로젝트는 Naver cloud platform(NCP)과 Terraform을 이용하여 인프라를 생성, 관리합니다.
+아래는 프로젝트를 위한 인프라 생성 방법을 정리한 내용입니다.
+
+## Step 1 - NCP 준비
+- NCP에 가입합니다.
+- ncloud.com > 마이페이지 > "인증키 관리" 메뉴에서 API 인증키를 생성하고 다음이 생성되었는지 확인합니다.
+  - Access Key ID
+  - Secret Key
+
+## Step 2 - Terraform CLI 설치
+- https://developer.hashicorp.com/terraform/tutorials/aws-get-started/install-cli 
+  - Install Terraform, Verify the installation 까지만 진행
+
+## Step 3 - Terraform Cloud 준비
+Terraform Cloud에 프로젝트의 infra 구성 결과(.tfstate 파일)를 저장하는 공간을 만듭니다.
+로컬에 구성 결과를 저장할 수도 있지만 실수로 해당 파일을 지울 수도 있기 때문에, 클라우드에 저장하는 것이 좀 더 안전합니다.
+
+- Terraform Cloud에 가입합니다.
+- (optional) organization 이름을 원하는 것으로 변경합니다.
+- "food-reservation" 이라는 이름으로 workspace를 생성합니다.
+- "food-reservation" workspace의 "Variables" 메뉴에서 다음의 Workspace Variable을 생성합니다.
+  - ncp_secret_key
+    - category: Terraform variable
+    - key: ncp_secret_key
+    - value: NCP의 Access Key ID 값
+  - ncp_access_key
+    - category: Terraform variable
+    - key: ncp_access_key
+    - value: NCP의 Secret Key 값
+  - 참고: "Sensitive" 란을 체크하면 웹 페이지에서 값을 안 보이도록 할 수 있기에 설정하는 게 보안에 더 좋습니다.
+
+## Step 4 - 인프라 생성
+이제 준비가 끝났습니다. terraform 명령어를 이용하여 NCP에 인프라를 생성합니다.
+- 터미널 루트를 이 폴더(infra)에 놓습니다.
+- terraform cloud organization 이름을 환경 변수 TF_CLOUD_ORGANIZATION 에 지정합니다.
+  ```shell
+  $ export TF_CLOUD_ORGANIZATION=<Terraform cloud organization 이름>
+  ```
+- 필요한 terraform 설정을 하도록 초기화 명령합니다.
+  ```shell
+  $ terraform init # "Terraform Cloud has been successfully initialized!" 문구가 출력되면 초기화 성공.
+  ```
+- infra 구성을 명령합니다.
+  ```shell
+  $ terraform apply  
+  ```
+  - "Plan: x to add, 0 to change, 0 to destroy" 등과 같이 생성할 리소스 개수에 대한 정보가 출력됩니다.
+  - "Do you want to perform these actions in workspace "food-reservation"?" 에 "yes"를 입력합니다.
+  - NCP에 리소스 생성이 시작됩니다. 완료까지 4 ~ 10분 정도 소요됩니다.
+- NCP console에서 생성된 리소스를 확인합니다.
+- Terraform cloud에서 지정한 organization, food-reservation workspace에 리소스 구성 결과가 저장되어 있는지 확인합니다.
+
+## Step 5 - 서버에 ssh 접속, 초기화
+생성된 public ip를 통해 서버에 ssh 접속 확인합니다.
+- ssh 접속합니다.
+  ```shell
+  $ ssh root@<public ip> -p 22
+  ```
+  - 필요한 public ip, root password는 food-reservation workspace의 "States"에서 확인할 수 있습니다.
+- infra/server-scripts 안의 스크립트들을 실행시켜서 초기화 시켜줍니다.

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -18,7 +18,7 @@ resource "ncloud_vpc" "vpc" {
 # Public Subnet
 resource "ncloud_subnet" "subnet_public" {
   network_acl_no = ncloud_network_acl.acl_public.id
-  subnet         = cidrsubnet(ncloud_vpc.vpc.ipv4_cidr_block, 8, 0)  // "10.0.0.0/24"
+  subnet         = cidrsubnet(ncloud_vpc.vpc.ipv4_cidr_block, 8, 0) // "10.0.0.0/24"
   subnet_type    = "PUBLIC"
   vpc_no         = ncloud_vpc.vpc.id
   zone           = "KR-1"
@@ -38,11 +38,49 @@ resource "ncloud_login_key" "login_key" {
 
 # Server
 resource "ncloud_server" "server_public" {
-  subnet_no = ncloud_subnet.subnet_public.id
-  name      = "server-${local.project_name}"
+  subnet_no                 = ncloud_subnet.subnet_public.id
+  name                      = "server-${local.project_name}"
   server_image_product_code = var.server_image_product_code
-  server_product_code = var.server_product_code
-  login_key_name = ncloud_login_key.login_key.key_name
+  server_product_code       = var.server_product_code
+  login_key_name            = ncloud_login_key.login_key.key_name
+}
+
+# Server 초기화 스크립트 실행을 위한 null_resource, provisioners
+resource "null_resource" "server_init" {
+  connection {
+    type     = "ssh"
+    host     = ncloud_public_ip.public_ip.public_ip
+    user     = "root"
+    port     = "22"
+    password = data.ncloud_root_password.root_password.root_password
+  }
+
+  triggers = {
+    server_instance_id = ncloud_server.server_public.id # server instance 가 파괴되고 새로 만들어질 때마다 스크립트 실행
+  }
+
+  depends_on = [ncloud_server.server_public, ncloud_public_ip.public_ip] # server, public ip 생성 이후 스크립트 실행
+
+  provisioner "remote-exec" {
+    inline = [
+      "mkdir -p food-reservation/infra"
+    ]
+  }
+
+  provisioner "file" {
+    source      = "./server-scripts"
+    destination = "food-reservation/infra"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sh food-reservation/infra/server-scripts/installing-docker.sh"
+    ]
+  }
+
+  #  provisioner "remote-exec" {
+  #    script = "./server-scripts/installing-docker.sh"
+  #  }
 }
 
 # Public IP
@@ -52,7 +90,7 @@ resource "ncloud_public_ip" "public_ip" {
 
 data "ncloud_root_password" "root_password" {
   server_instance_no = ncloud_server.server_public.id
-  private_key = ncloud_login_key.login_key.private_key
+  private_key        = ncloud_login_key.login_key.private_key
 }
 
 // TODO - default ACG 포트 설정

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -92,5 +92,3 @@ data "ncloud_root_password" "root_password" {
   server_instance_no = ncloud_server.server_public.id
   private_key        = ncloud_login_key.login_key.private_key
 }
-
-// TODO - default ACG 포트 설정

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -45,6 +45,12 @@ resource "ncloud_server" "server_public" {
   login_key_name            = ncloud_login_key.login_key.key_name
 }
 
+/*
+Init Script 리소스를 이용하여 installing-docker.sh 실행 시도 시 실패
+- server 가 init script 실행 하는 시점이, server 생성은 되었지만 public ip 는 아직 생성 및 부착되기 전
+- 즉, 인터넷 연결을 못 하는 시점에 init script 실행이 되어 인터넷으로 docker 를 설치하려 하므로 설치 실패하게 됨
+- 번거롭지만 null_resource, provisioner 를 사용하여 직접 스크립트를 복사하고 실행하는 것으로 해결함
+*/
 # Server 초기화 스크립트 실행을 위한 null_resource, provisioners
 resource "null_resource" "server_init" {
   connection {

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -77,10 +77,6 @@ resource "null_resource" "server_init" {
       "sh food-reservation/infra/server-scripts/installing-docker.sh"
     ]
   }
-
-  #  provisioner "remote-exec" {
-  #    script = "./server-scripts/installing-docker.sh"
-  #  }
 }
 
 # Public IP

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,58 @@
+provider "ncloud" {
+  support_vpc = true
+  region      = "KR"
+  access_key  = var.ncp_access_key
+  secret_key  = var.ncp_secret_key
+}
+
+locals {
+  project_name = "food-reservation"
+}
+
+# VPC
+resource "ncloud_vpc" "vpc" {
+  ipv4_cidr_block = "10.0.0.0/16"
+  name            = "vpc-${local.project_name}"
+}
+
+# Public Subnet
+resource "ncloud_subnet" "subnet_public" {
+  network_acl_no = ncloud_network_acl.acl_public.id
+  subnet         = cidrsubnet(ncloud_vpc.vpc.ipv4_cidr_block, 8, 0)  // "10.0.0.0/24"
+  subnet_type    = "PUBLIC"
+  vpc_no         = ncloud_vpc.vpc.id
+  zone           = "KR-1"
+  name           = "subnet-${local.project_name}"
+}
+
+# Network ACL
+resource "ncloud_network_acl" "acl_public" {
+  vpc_no = ncloud_vpc.vpc.id
+  name   = "acl-public-${local.project_name}"
+}
+
+# Login Key
+resource "ncloud_login_key" "login_key" {
+  key_name = local.project_name
+}
+
+# Server
+resource "ncloud_server" "server_public" {
+  subnet_no = ncloud_subnet.subnet_public.id
+  name      = "server-${local.project_name}"
+  server_image_product_code = var.server_image_product_code
+  server_product_code = var.server_product_code
+  login_key_name = ncloud_login_key.login_key.key_name
+}
+
+# Public IP
+resource "ncloud_public_ip" "public_ip" {
+  server_instance_no = ncloud_server.server_public.id
+}
+
+data "ncloud_root_password" "root_password" {
+  server_instance_no = ncloud_server.server_public.id
+  private_key = ncloud_login_key.login_key.private_key
+}
+
+// TODO - default ACG 포트 설정

--- a/infra/security.tf
+++ b/infra/security.tf
@@ -1,0 +1,10 @@
+resource "ncloud_access_control_group_rule" "acg_rules" {
+  access_control_group_no = ncloud_vpc.vpc.default_access_control_group_no
+
+  inbound {
+    protocol    = "TCP"
+    ip_block    = "0.0.0.0/0"
+    port_range  = "80"
+    description = "added by terraform"
+  }
+}

--- a/infra/server-scripts/installing-docker.sh
+++ b/infra/server-scripts/installing-docker.sh
@@ -1,0 +1,21 @@
+# https://docs.docker.com/engine/install/ubuntu/
+
+## Set up the repository
+sudo apt-get update
+sudo apt-get install \
+ca-certificates \
+curl \
+gnupg \
+lsb-release
+
+sudo mkdir -p /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+  $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+
+## Install Docker Engine
+sudo apt-get update
+sudo apt-get install docker-ce docker-ce-cli containerd.io docker-compose-plugin

--- a/infra/server-scripts/installing-docker.sh
+++ b/infra/server-scripts/installing-docker.sh
@@ -1,8 +1,9 @@
+#!/bin/bash
 # https://docs.docker.com/engine/install/ubuntu/
 
-## Set up the repository
 sudo apt-get update
-sudo apt-get install \
+# modified: -y added
+sudo apt-get -y install \
 ca-certificates \
 curl \
 gnupg \
@@ -15,7 +16,6 @@ echo \
   "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
   $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 
-
-## Install Docker Engine
 sudo apt-get update
-sudo apt-get install docker-ce docker-ce-cli containerd.io docker-compose-plugin
+# modified: -y added
+sudo apt-get -y install docker-ce docker-ce-cli containerd.io docker-compose-plugin

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,23 +1,23 @@
 variable "ncp_access_key" {
-  type = string
+  type        = string
   description = "ncp access key id"
 }
 
 variable "ncp_secret_key" {
-  type = string
+  type        = string
   description = "ncp secret key"
 }
 
 variable "server_image_product_code" {
-  type = string
+  type        = string
   description = "ncp server image product code"
-  default = "SW.VSVR.OS.LNX64.UBNTU.SVR2004.B050" // ubuntu-20.04
+  default     = "SW.VSVR.OS.LNX64.UBNTU.SVR2004.B050" // ubuntu-20.04
   // https://github.com/NaverCloudPlatform/terraform-ncloud-docs/blob/main/docs/server_image_product.md
 }
 
 variable "server_product_code" {
-  type = string
+  type        = string
   description = "ncp server product code"
-  default = "SVR.VSVR.HICPU.C002.M004.NET.SSD.B050.G002" // vCPU 2EA, Memory 4GB, [SSD]Disk 50GB
+  default     = "SVR.VSVR.HICPU.C002.M004.NET.SSD.B050.G002" // vCPU 2EA, Memory 4GB, [SSD]Disk 50GB
   // https://github.com/NaverCloudPlatform/terraform-ncloud-docs/blob/main/docs/vpc_products/ubuntu-20.04.md
 }

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,23 @@
+variable "ncp_access_key" {
+  type = string
+  description = "ncp access key id"
+}
+
+variable "ncp_secret_key" {
+  type = string
+  description = "ncp secret key"
+}
+
+variable "server_image_product_code" {
+  type = string
+  description = "ncp server image product code"
+  default = "SW.VSVR.OS.LNX64.UBNTU.SVR2004.B050" // ubuntu-20.04
+  // https://github.com/NaverCloudPlatform/terraform-ncloud-docs/blob/main/docs/server_image_product.md
+}
+
+variable "server_product_code" {
+  type = string
+  description = "ncp server product code"
+  default = "SVR.VSVR.HICPU.C002.M004.NET.SSD.B050.G002" // vCPU 2EA, Memory 4GB, [SSD]Disk 50GB
+  // https://github.com/NaverCloudPlatform/terraform-ncloud-docs/blob/main/docs/vpc_products/ubuntu-20.04.md
+}

--- a/infra/versions.tf
+++ b/infra/versions.tf
@@ -6,9 +6,8 @@ terraform {
   }
 
   cloud {
-    //organization = ""
-    //적어놓기 보다는 동적으로(환경변수로) 입력하도록 변경. terraform 명령어 내리기 전 환경변수 설정 필요.
-    // ==> export TF_CLOUD_ORGANIZATION=...
+    // organization = ""
+    // terraform 명령어 내리기 전 환경변수 설정 필요 ==> export TF_CLOUD_ORGANIZATION=...
     workspaces {
       name = "food-reservation"
     }

--- a/infra/versions.tf
+++ b/infra/versions.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    ncloud = {
+      source = "navercloudplatform/ncloud"
+    }
+  }
+
+  cloud {
+    //organization = ""
+    //적어놓기 보다는 동적으로(환경변수로) 입력하도록 변경. terraform 명령어 내리기 전 환경변수 설정 필요.
+    // ==> export TF_CLOUD_ORGANIZATION=...
+    workspaces {
+      name = "food-reservation"
+    }
+  }
+}


### PR DESCRIPTION
terraform을 이용하여 NCP에 인프라를 설정할 수 있도록 하였습니다.
1. terraform 파일을 추가하였습니다.
  - NCP에 인프라를 구성하도록 terraform을 작성하였습니다.
  - 구성 결과는 terraform cloud에 저장하도록 하였습니다.
  - vpc, public subnet, server, public ip 등으로 구성된 간단한 인프라입니다.
2. 인프라 구성 방법을 설명한 README.md 파일을 추가하였습니다.
