### PR TITLE
[CD] 서버 배포 workflow 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,55 @@
+name: deploy
+
+on:
+  workflow_call:
+    inputs:
+      IMAGE_NAME:
+        description: 배포할 image name
+        type: string
+        required: true
+      ENV_NAME:
+        # github repository Settings > Environments 에 input 으로 전달되는 ENV_NAME 과 동일한 환경이 존재해야
+        # 해당 환경에서 배포가 이루어집니다.
+        # 또한, 각 환경마다 HOST, USERNAME, PASSWORD, PORT 를 Secret 으로 가지고 있어야 합니다.
+        # HOST : 배포 서버의 퍼블릭 ip
+        # USERNAME : 배포 서버 접속 계정 이름 (예: root)
+        # PASSWORD : 배포 서버 접속 비밀번호
+        # PORT : 배포 서버 ssh 접속 포트번호 (예: 22)
+        description: 배포 환경 이름
+        type: string
+        required: true
+
+jobs:
+  deploy-to-server:
+    environment:
+      name: ${{ inputs.ENV_NAME }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Copy script, docker compose files
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
+          password: ${{ secrets.PASSWORD }}
+          port: ${{ secrets.PORT }}
+          source: "script/prod.sh,docker-compose-prod.yml"
+          target: "food-reservation"
+
+      - name: Docker compose up
+        uses: appleboy/ssh-action@master
+        env:
+          IMAGE_NAME: ${{ inputs.IMAGE_NAME }}
+          JEP: ${{ secrets.JEP }}
+        with:
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
+          password: ${{ secrets.PASSWORD }}
+          port: ${{ secrets.PORT }}
+          envs: IMAGE_NAME, JEP
+          script: |
+            export IMAGE_NAME=$IMAGE_NAME
+            export JEP=$JEP
+            cd food-reservation
+            sh script/prod.sh

--- a/.github/workflows/image-build-and-push.yml
+++ b/.github/workflows/image-build-and-push.yml
@@ -13,8 +13,10 @@ env:
   IMAGE_NAME: oldrabbit736/food-reservation-app:0.0.${{ github.run_number }}
 
 jobs:
-  build-push-deploy:
+  build-push:
     runs-on: ubuntu-latest
+    outputs:
+      IMAGE_NAME: ${{ steps.image-name-output.outputs.image-name }}
     steps:
       - uses: actions/checkout@v3
 
@@ -52,5 +54,33 @@ jobs:
       - name: Push to container registry
         run: docker push ${{ env.IMAGE_NAME }}
 
-      # TODO:
-      #- name: Deploy to production server
+      - name: Set image name output
+        id: image-name-output
+        run: echo "::set-output name=image-name::${{ env.IMAGE_NAME }}"
+
+  # 각 environment 로 배포 작업 - 각 environment 마다 job 1개 씩 지정, job 은 deploy.yml workflow 재사용
+  # 각 environment 마다 job 1개 씩 지정 하는 것 대신 matrix 에 environment 를 리스트 형식으로 지정하고 대신 job 을 1개로 유지하는 방식도 시도해보았으나,
+  # matrix 참고: https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/reusing-workflows#example-matrix-strategy-with-a-reusable-workflow
+  # 한 가지 문제가 있었는데, parallel instance 중 하나라도 실패하면 나머지 작업도 cancel 시켜버린다는 점입니다. (fast fail)
+  # 각 작업이 서로의 성공여부에 상관없이 독립적으로 동작하게 만들기 위해, 비록 약간의 duplication 이 발생하지만, 아래와 같이 job 을 2개로 나누는 방법으로 변경하였습니다.
+  deploy-js:
+    needs: build-push
+    uses: ./.github/workflows/deploy.yml
+    with:
+      ENV_NAME: PROD_JS
+      IMAGE_NAME: ${{ needs.build-push.outputs.IMAGE_NAME }}
+      # 이전 job 의 output 으로 IMAGE_NAME 전달
+      # IMAGE_NAME: ${{ env.IMAGE_NAME }} 과 같이 직접적으로 env context 를 이용하려 하였으나, github actions 가 설정한 한계에 의해 불가능합니다.
+      # 다음 링크의 Limitations 의 마지막 세 번째 항목 참조: https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/reusing-workflows#limitations
+      # 따라서 workaround 로 job 의 output 을 통해 전달하는 방식을 택하였습니다.
+      # 참고1: https://stackoverflow.com/questions/73305126/passing-env-variable-inputs-to-a-reusable-workflow
+      # 참고2: https://github.com/orgs/community/discussions/26671
+    secrets: inherit
+
+  deploy-ms:
+    needs: build-push
+    uses: ./.github/workflows/deploy.yml
+    with:
+      ENV_NAME: PROD_MS
+      IMAGE_NAME: ${{ needs.build-push.outputs.IMAGE_NAME }}
+    secrets: inherit

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,0 +1,21 @@
+services:
+  mariadb:
+    image: mariadb:10.9.2
+    environment:
+      MARIADB_ROOT_PASSWORD: password
+      MARIADB_DATABASE: food-reservation
+    ports:
+      - "3306:3306"
+  app:
+    # https://docs.docker.com/compose/compose-file/#interpolation
+    # ${IMAGE_NAME}, ${JEP} 는 docker compose 를 실행시키는 서버의 환경변수로부터 받아옵니다.
+    image: ${IMAGE_NAME}
+    restart: always
+    depends_on:
+      - mariadb
+    ports:
+      - "80:8080"
+    environment:
+      SPRING_PROFILES_ACTIVE: prod
+      JEP: ${JEP}
+      SPRING_DATASOURCE_URL: jdbc:mariadb://mariadb:3306/food-reservation

--- a/script/prod.sh
+++ b/script/prod.sh
@@ -1,0 +1,15 @@
+# production server 환경에서 실행되는 스크립트입니다.
+# 스크립트 실행 전 IMAGE_NAME, JEP 환경변수 설정이 필요합니다. CD 과정에서 자동으로 설정됩니다.
+
+if [ -z "${IMAGE_NAME}" ]; then
+  echo "스크립트 실행 전 IMAGE_NAME 환경변수 값을 설정해 주세요!"
+  exit 1
+fi
+
+if [ -z "${JEP}" ]; then
+  echo "스크립트 실행 전 JEP 환경변수 값을 설정해 주세요!"
+  exit 1
+fi
+
+echo up compose...
+docker compose -f docker-compose-prod.yml --project-name food-reservation-prod up -d


### PR DESCRIPTION
CD가 다음과 같이 진행하도록 하였습니다.

- PR merge 발생
- PR commit 대상으로 image-build-and-push workflow 진행 (build 후, docker image 생성, dockerhub으로 push)
- deploy workflow 진행 (이 부분이 이번 PR의 내용입니다.)
  - 2개의 환경(PROD_JS, PROD_MS)을 대상으로 배포 진행합니다. 이 때 각 환경의 주인은 deploy 진행을 approve나 reject할 수 있습니다. 아래는 approve 되었을 경우 진행되는 내용입니다.
  - scp를 통해 script(docker compose up 실행), docker compose 파일을 복사합니다.
  - ssh를 통해 script를 실행시켜 docker compose up 명령을 실행합니다. 이 때 전 단계에서 dockerhub으로 push된 이미지를 다운받아 실행시킵니다.
