### PR TITLE
[FEATURE] Seller 생성 endpoint 추가

### DIFF
--- a/.github/workflows/image-build-push-deploy.yml
+++ b/.github/workflows/image-build-push-deploy.yml
@@ -1,4 +1,4 @@
-name: Image build and push
+name: Image build, push and deploy
 
 on:
   push:
@@ -33,10 +33,6 @@ jobs:
       # https://github.com/marketplace/actions/gradle-build-action#build-scans
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
-
-      # docker compose 이용하여 test 수행에 필요한 외부 서비스 실행
-      - name: Set up test environment
-        run: sh script/test-ci.sh
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,10 +25,6 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
 
-      # docker compose 이용하여 test 수행에 필요한 외부 서비스 실행
-      - name: Set up test environment
-        run: sh script/test-ci.sh
-
       # build task 를 수행하는 과정에서 test, integration test task 실행
       - name: build
         run: ./gradlew build --scan

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
     ext {
         queryDslVersion = "5.0.0"
+        testcontainersVersion = "1.17.4"
     }
 }
 
@@ -27,22 +28,30 @@ repositories {
 }
 
 dependencies {
+    annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}"
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.4'
+    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
     implementation 'io.jsonwebtoken:jjwt:0.9.1'
     implementation 'javax.xml.bind:jaxb-api:2.3.1'
-    implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.4'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.springframework.security:spring-security-test:5.7.3'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'org.testcontainers:junit-jupiter'
+    testImplementation 'org.testcontainers:mariadb'
     testRuntimeOnly 'com.h2database:h2'
-    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
-    annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}"
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.testcontainers:testcontainers-bom:${testcontainersVersion}"
+    }
 }
 
 tasks.named('test') {

--- a/app/src/main/java/com/foodlab/foodReservation/auth/config/SecurityConfig.java
+++ b/app/src/main/java/com/foodlab/foodReservation/auth/config/SecurityConfig.java
@@ -3,23 +3,28 @@ package com.foodlab.foodReservation.auth.config;
 import com.foodlab.foodReservation.auth.token.JwtFilter;
 import com.foodlab.foodReservation.auth.token.JwtProvider;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 
 @Configuration
 @RequiredArgsConstructor
-public class SecurityConfig extends WebSecurityConfigurerAdapter {
+public class SecurityConfig {
 
     private final CustomOAuth2UserService oAuth2UserService;
     private final OAuth2SuccessHandler successHandler;
     private final JwtProvider jwtProvider;
 
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
+    @Bean
+    @Order(1)
+    public SecurityFilterChain configure(HttpSecurity http) throws Exception {
         http
                 .httpBasic().disable()
                 .csrf().disable()
@@ -34,5 +39,29 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .userInfoEndpoint().userService(oAuth2UserService);
 
         http.addFilterBefore(new JwtFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    /**
+     * Seller api 를 위한 SecurityFilterChain 정의 (/sellers/**)
+     */
+    @Bean
+    @Order(0)
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.antMatcher("/sellers/**")
+                .authorizeRequests()
+                .antMatchers("POST", "/sellers").permitAll()
+                .anyRequest().authenticated()
+                .and()
+                .csrf().disable()
+        ;
+
+        return http.build();
     }
 }

--- a/app/src/main/java/com/foodlab/foodReservation/seller/controller/SellerController.java
+++ b/app/src/main/java/com/foodlab/foodReservation/seller/controller/SellerController.java
@@ -1,0 +1,26 @@
+package com.foodlab.foodReservation.seller.controller;
+
+import com.foodlab.foodReservation.seller.dto.request.CreateSellerRequest;
+import com.foodlab.foodReservation.seller.dto.response.CreateSellerResponse;
+import com.foodlab.foodReservation.seller.service.SellerService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@RestController
+@RequiredArgsConstructor
+public class SellerController {
+
+    private final SellerService sellerService;
+
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping("/sellers")
+    public CreateSellerResponse createSeller(@RequestBody @Valid CreateSellerRequest createSellerRequest) {
+        return sellerService.createSeller(createSellerRequest);
+    }
+}

--- a/app/src/main/java/com/foodlab/foodReservation/seller/dto/request/CreateSellerRequest.java
+++ b/app/src/main/java/com/foodlab/foodReservation/seller/dto/request/CreateSellerRequest.java
@@ -1,0 +1,15 @@
+package com.foodlab.foodReservation.seller.dto.request;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@RequiredArgsConstructor
+public class CreateSellerRequest {
+    @NotBlank
+    private final String username;
+    @NotBlank
+    private final String password;
+}

--- a/app/src/main/java/com/foodlab/foodReservation/seller/dto/response/CreateSellerResponse.java
+++ b/app/src/main/java/com/foodlab/foodReservation/seller/dto/response/CreateSellerResponse.java
@@ -1,0 +1,11 @@
+package com.foodlab.foodReservation.seller.dto.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CreateSellerResponse {
+    private final Long id;
+    private final String username;
+}

--- a/app/src/main/java/com/foodlab/foodReservation/seller/entity/Seller.java
+++ b/app/src/main/java/com/foodlab/foodReservation/seller/entity/Seller.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -26,6 +27,7 @@ public class Seller {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(unique = true)
     private String username;
 
     private String password;

--- a/app/src/main/java/com/foodlab/foodReservation/seller/repository/SellerRepository.java
+++ b/app/src/main/java/com/foodlab/foodReservation/seller/repository/SellerRepository.java
@@ -3,6 +3,9 @@ package com.foodlab.foodReservation.seller.repository;
 import com.foodlab.foodReservation.seller.entity.Seller;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface SellerRepository extends JpaRepository<Seller, Long> {
 
+    Optional<Seller> findByUsername(String username);
 }

--- a/app/src/main/java/com/foodlab/foodReservation/seller/service/SellerService.java
+++ b/app/src/main/java/com/foodlab/foodReservation/seller/service/SellerService.java
@@ -1,0 +1,35 @@
+package com.foodlab.foodReservation.seller.service;
+
+import com.foodlab.foodReservation.seller.dto.request.CreateSellerRequest;
+import com.foodlab.foodReservation.seller.dto.response.CreateSellerResponse;
+import com.foodlab.foodReservation.seller.entity.Seller;
+import com.foodlab.foodReservation.seller.repository.SellerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SellerService {
+
+    private final SellerRepository sellerRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public CreateSellerResponse createSeller(CreateSellerRequest request) {
+
+        sellerRepository.findByUsername(request.getUsername())
+                .ifPresent((seller) -> {
+                    throw new IllegalArgumentException("이미 사용중인 username 입니다.");
+                });
+
+        Seller seller = Seller.builder()
+                .username(request.getUsername())
+                .password(passwordEncoder.encode(request.getPassword()))
+                .build();
+
+        Seller savedSeller = sellerRepository.save(seller);
+        return new CreateSellerResponse(savedSeller.getId(), savedSeller.getUsername());
+    }
+}

--- a/app/src/main/resources/config/auth/application-test.yml
+++ b/app/src/main/resources/config/auth/application-test.yml
@@ -1,0 +1,11 @@
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: dummy
+            client-secret: dummy
+
+token-secret-key: dummy
+token-refresh-key: dummy

--- a/app/src/main/resources/config/db/application-test.yml
+++ b/app/src/main/resources/config/db/application-test.yml
@@ -1,3 +1,0 @@
-spring:
-  datasource:
-    url: jdbc:mariadb://localhost:3307/food-reservation

--- a/app/src/main/resources/config/hibernate/application-test.yml
+++ b/app/src/main/resources/config/hibernate/application-test.yml
@@ -1,0 +1,12 @@
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        #show_sql: true
+        format_sql: true
+        default_batch_fetch_size: 100
+logging.level:
+  org.hibernate.SQL: debug
+  #org.hibernate.type: trace

--- a/app/src/main/resources/config/jasypt/application-test.yml
+++ b/app/src/main/resources/config/jasypt/application-test.yml
@@ -1,0 +1,3 @@
+jasypt:
+  encryptor:
+    password: dummy

--- a/app/src/test/java/com/foodlab/foodReservation/seller/controller/SellerControllerIntegrationTest.java
+++ b/app/src/test/java/com/foodlab/foodReservation/seller/controller/SellerControllerIntegrationTest.java
@@ -1,0 +1,79 @@
+package com.foodlab.foodReservation.seller.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.foodlab.foodReservation.seller.dto.request.CreateSellerRequest;
+import com.foodlab.foodReservation.testUtils.TestContainerBase;
+import org.hamcrest.core.Is;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.http.MediaType.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * 다음 요소들의 integration test
+ * Filter -> Controller -> Service -> Repository -> DB
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class SellerControllerIntegrationTest extends TestContainerBase {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Test
+    void createSeller_whenValidRequest_thenShouldReturnCreationResult() throws Exception {
+        // given
+        CreateSellerRequest request = new CreateSellerRequest("user", "1234");
+        // when, then
+        mockMvc.perform(MockMvcRequestBuilders.post("/sellers")
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                )
+                .andDo(print())
+                //.andExpect(jsonPath("status", Is.is("SUCCESS"))) // TODO: API response 포맷 통일하고, 통일된 모양으로 테스트하기
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("id", Is.isA(Integer.class)))
+                .andExpect(jsonPath("username", Is.is("user")));
+    }
+
+    @Test
+    void createSeller_whenBlankUsername_thenShouldReturnBadRequest() throws Exception {
+        // given
+        CreateSellerRequest request = new CreateSellerRequest("", "1234");
+        // when, then
+        mockMvc.perform(MockMvcRequestBuilders.post("/sellers")
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest()); // TODO: API response 포맷 통일하고, 통일된 모양으로 테스트하기
+    }
+
+    @Test
+    void createSeller_whenDuplicateUsername_thenShouldReturnBadRequest() throws Exception {
+        // given
+        CreateSellerRequest request = new CreateSellerRequest("user", "1234");
+        mockMvc.perform(MockMvcRequestBuilders.post("/sellers")
+                .contentType(APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        );
+        // when, then
+        mockMvc.perform(MockMvcRequestBuilders.post("/sellers")
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                )
+                .andDo(print())
+                .andExpect(status().is5xxServerError()); // TODO: API response 포맷 통일하고, 통일된 모양으로 테스트하기
+    }
+}

--- a/app/src/test/java/com/foodlab/foodReservation/seller/entity/SellerIntegrationTest.java
+++ b/app/src/test/java/com/foodlab/foodReservation/seller/entity/SellerIntegrationTest.java
@@ -1,0 +1,51 @@
+package com.foodlab.foodReservation.seller.entity;
+
+import com.foodlab.foodReservation.testUtils.TestContainerBase;
+import org.hibernate.exception.ConstraintViolationException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import javax.persistence.PersistenceException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * 다음 요소들의 integration test
+ * Entity -> DB
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class SellerIntegrationTest extends TestContainerBase {
+
+    @Autowired
+    TestEntityManager testEntityManager;
+
+    @Test
+    void sellerEntity_whenValidSellerProvided_thenShouldBeStored() {
+        // given
+        Seller seller = Seller.builder().username("user").password("1234").build();
+        // when
+        Seller savedSeller = testEntityManager.persistFlushFind(seller);
+        // then
+        assertThat(savedSeller.getUsername()).isEqualTo("user");
+        assertThat(savedSeller.getPassword()).isEqualTo("1234");
+        assertThat(savedSeller.getStoreList()).isEmpty();
+    }
+
+    @Test
+    void sellerEntity_whenDuplicateUsernameProvided_thenShouldRejectToStore() {
+        // given
+        Seller seller1 = Seller.builder().username("user").password("1234").build();
+        testEntityManager.persistAndFlush(seller1);
+        // when
+        Seller seller2 = Seller.builder().username("user").password("abcd").build();
+        // then
+        assertThatThrownBy(() -> testEntityManager.persistAndFlush(seller2))
+                .isInstanceOf(PersistenceException.class)
+                .hasCauseInstanceOf(ConstraintViolationException.class);
+    }
+}

--- a/app/src/test/java/com/foodlab/foodReservation/seller/repository/SellerRepositoryIntegrationTest.java
+++ b/app/src/test/java/com/foodlab/foodReservation/seller/repository/SellerRepositoryIntegrationTest.java
@@ -1,0 +1,45 @@
+package com.foodlab.foodReservation.seller.repository;
+
+import com.foodlab.foodReservation.seller.entity.Seller;
+import com.foodlab.foodReservation.testUtils.TestContainerBase;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 다음 요소들의 integration test
+ * Repository -> DB
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class SellerRepositoryIntegrationTest extends TestContainerBase {
+
+    @Autowired
+    SellerRepository sellerRepository;
+
+    @Test
+    void findByUsername_whenNoSellerUsernameMatch_thenShouldReturnEmpty() {
+        // when
+        Optional<Seller> foundSeller = sellerRepository.findByUsername("oldrabbit");
+        // then
+        assertThat(foundSeller).isEmpty();
+    }
+
+    @Test
+    void findByUsername_whenSellerUsernameMatch_thenShouldReturnSeller() {
+        // given
+        Seller seller = Seller.builder().username("oldrabbit").password("1234").build();
+        sellerRepository.saveAndFlush(seller);
+        // when
+        Seller foundSeller = sellerRepository.findByUsername("oldrabbit").orElseThrow();
+        // then
+        assertThat(foundSeller.getUsername()).isEqualTo("oldrabbit");
+        assertThat(foundSeller.getPassword()).isEqualTo("1234");
+        assertThat(foundSeller.getStoreList()).isNull();
+    }
+}

--- a/app/src/test/java/com/foodlab/foodReservation/seller/service/SellerServiceIntegrationTest.java
+++ b/app/src/test/java/com/foodlab/foodReservation/seller/service/SellerServiceIntegrationTest.java
@@ -1,0 +1,76 @@
+package com.foodlab.foodReservation.seller.service;
+
+import com.foodlab.foodReservation.seller.dto.request.CreateSellerRequest;
+import com.foodlab.foodReservation.seller.dto.response.CreateSellerResponse;
+import com.foodlab.foodReservation.seller.entity.Seller;
+import com.foodlab.foodReservation.testUtils.TestContainerBase;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureTestEntityManager;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
+
+
+import static org.assertj.core.api.Assertions.*;
+
+
+/**
+ * 다음 요소들의 integration test
+ * Service -> Repository -> DB
+ */
+@SpringBootTest
+@AutoConfigureTestEntityManager
+@Transactional
+class SellerServiceIntegrationTest extends TestContainerBase {
+
+    @Autowired
+    TestEntityManager tem;
+
+    @Autowired
+    PasswordEncoder passwordEncoder;
+
+    @Autowired
+    SellerService sellerService;
+
+    @Test
+    void createSeller_whenNoDuplicateUsername_thenShouldSaveSeller() {
+        // given
+        CreateSellerRequest request = new CreateSellerRequest("user", "1234");
+        // when
+        CreateSellerResponse savedSeller = sellerService.createSeller(request);
+        tem.flush();
+        tem.clear();
+        Seller foundSeller = tem.find(Seller.class, savedSeller.getId());
+        // then
+        assertThat(foundSeller.getUsername()).isEqualTo("user");
+    }
+
+    @Test
+    void createSeller_whenSellerIsPersisted_thenPasswordShouldBeEncoded() {
+        // given
+        CreateSellerRequest request = new CreateSellerRequest("user", "1234");
+        // when
+        CreateSellerResponse savedSeller = sellerService.createSeller(request);
+        tem.flush();
+        tem.clear();
+        Seller seller = tem.find(Seller.class, savedSeller.getId());
+        // then
+        assertThat(passwordEncoder.matches("1234", seller.getPassword())).isTrue();
+    }
+
+    @Test
+    void createSeller_whenDuplicateUsername_thenShouldThrow() {
+        // given
+        CreateSellerRequest request = new CreateSellerRequest("user", "1234");
+        sellerService.createSeller(request);
+        tem.flush();
+        tem.clear();
+        // when, then
+        assertThatThrownBy(() -> sellerService.createSeller(request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("이미 사용중인 username 입니다.");
+    }
+
+}

--- a/app/src/test/java/com/foodlab/foodReservation/seller/service/SellerServiceUnitTest.java
+++ b/app/src/test/java/com/foodlab/foodReservation/seller/service/SellerServiceUnitTest.java
@@ -1,0 +1,69 @@
+package com.foodlab.foodReservation.seller.service;
+
+import com.foodlab.foodReservation.seller.dto.request.CreateSellerRequest;
+import com.foodlab.foodReservation.seller.dto.response.CreateSellerResponse;
+import com.foodlab.foodReservation.seller.entity.Seller;
+import com.foodlab.foodReservation.seller.repository.SellerRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SellerServiceUnitTest {
+
+    @Mock
+    SellerRepository sellerRepository;
+
+    @Mock
+    PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    SellerService sellerService;
+
+    @Test
+    void createSeller_whenNoDuplicateUsername_thenShouldSaveSeller() {
+        // given
+        CreateSellerRequest request = new CreateSellerRequest("user", "1234");
+        when(sellerRepository.findByUsername(anyString())).thenReturn(Optional.empty());
+        when(sellerRepository.save(any(Seller.class))).thenReturn(Seller.builder().id(23L).username("user").password("1234").build());
+        when(passwordEncoder.encode(anyString())).thenReturn("encoded-password");
+        // when
+        CreateSellerResponse response = sellerService.createSeller(request);
+        // then
+        verify(sellerRepository).findByUsername(eq("user"));
+        assertThat(response.getUsername()).isEqualTo("user");
+        assertThat(response.getId()).isEqualTo(23L);
+    }
+
+    @Test
+    void createSeller_whenNoDuplicateUsername_thenPasswordShouldBeEncoded() {
+        // given
+        CreateSellerRequest request = new CreateSellerRequest("user", "1234");
+        when(sellerRepository.findByUsername(anyString())).thenReturn(Optional.empty());
+        when(sellerRepository.save(any(Seller.class))).thenReturn(Seller.builder().id(23L).username("user").password("1234").build());
+        when(passwordEncoder.encode(anyString())).thenReturn("encoded-password");
+        // when
+        sellerService.createSeller(request);
+        // then
+        verify(sellerRepository).save(argThat(seller -> seller.getUsername().equals("user")));
+        verify(sellerRepository).save(argThat(seller -> seller.getPassword().equals("encoded-password")));
+    }
+
+    @Test
+    void createSeller_whenDuplicateUsername_thenShouldThrow() {
+        // given
+        CreateSellerRequest request = new CreateSellerRequest("user", "1234");
+        when(sellerRepository.findByUsername(anyString())).thenReturn(Optional.of(Seller.builder().build()));
+        // when, then
+        assertThatThrownBy(() -> sellerService.createSeller(request))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/app/src/test/java/com/foodlab/foodReservation/testUtils/TestContainerBase.java
+++ b/app/src/test/java/com/foodlab/foodReservation/testUtils/TestContainerBase.java
@@ -1,0 +1,35 @@
+package com.foodlab.foodReservation.testUtils;
+
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MariaDBContainer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * test class 가 실행될 때마다 새로 test container 를 생성하는 대신, 미리 만들어둔 test container 를 사용할 수 있게 하는 Abstract class
+ * <a href="https://www.testcontainers.org/test_framework_integration/manual_lifecycle_control/">참고링크</a>
+ */
+@Testcontainers
+@ActiveProfiles("test")
+public class TestContainerBase {
+
+    // TODO: 추후 docker-compose 파일을 통해 로드되는 Testcontainer 지정하도록 변경 (연결되는 서비스가 늘어나면)
+    static final MariaDBContainer<?> mariadb;
+
+    static {
+        mariadb = new MariaDBContainer<>("mariadb:10.9.2");
+        mariadb.start();
+    }
+
+    /**
+     * 만약 테스트 별로 다른 ApplicationContext 를 사용해야 한다면 (이 메서드에서 ApplicationContext 를 변경하고 있다.)
+     * 이 메서드를 여기서 없애고 각 테스트 클래스마다 각자 놓는 것이 더 나을수도 있다.
+     */
+    @DynamicPropertySource
+    static void dynamicPropertySource(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", mariadb::getJdbcUrl);
+        registry.add("spring.datasource.username", mariadb::getUsername);
+        registry.add("spring.datasource.password", mariadb::getPassword);
+    }
+}

--- a/script/test-ci.sh
+++ b/script/test-ci.sh
@@ -1,4 +1,0 @@
-# CI 환경에서의 test 수행에 필요한 컨테이너를 실행시키는 스크립트입니다.
-# github workflow 가 사용합니다.
-# 로컬 컴퓨터에서 실행시킬 용도로 생성된 스크립트는 아닙니다.
-docker compose -f docker-compose-test.yml up -d

--- a/script/test-env.sh
+++ b/script/test-env.sh
@@ -1,6 +1,0 @@
-# app 테스트를 수행하기 위한 환경을 세팅하는 스크립트 입니다.
-# app 서비스 제외한 나머지 서비스가 실행됩니다.
-docker compose -f docker-compose-test.yml --project-name food-reservation-test up
-
-# 스크립트를 수행하여 환경을 세팅한 후, 앱의 테스트를 실행해야 합니다.
-# 테스트 클래스에 ActiveProfile("test") 를 적어주어, test 프로파일을 이용하여 실행될 수 있도록 해야 합니다.


### PR DESCRIPTION
Seller 생성 endpoint 추가하였습니다. (POST, /sellers)

1. 컴포넌트 추가
  - POST, /sellers 요청 수행을 위한 controller, service, repository 등을 생성, 수정하였습니다.
 
2. Seller 엔드포인트를 위한 SecurityFilterChain 추가
  - /sellers/** 경로에 적용되는 SecurityFilterChain을 추가하였습니다.
  - WebSecurityConfigurerAdapter를 삭제하고 각 SecurityFilterChain을 Bean으로 정의하는 방식으로 변경하였습니다. (WebSecurityConfigurerAdapter deprecated)
  - 결과적으로, /sellers/** 경로와 나머지 경로를 주관하는 2개의 SecurityFilterChain으로 구성하였습니다.
  - sellers에 대해 따로 필터를 구성한 이유는, 기존과는 다른 authentication, authorization을 적용할 예정이기 때문입니다. 특히 authentication으로는 formLogin, session, CSRF token repository 을 적용할 예정입니다.

3. Seller 테스트 추가, Testcontainer 도입
  - integration, unit 테스트를 추가하였습니다.
  - integration 테스트 시 필요한 컨테이너를 자동으로 생성할 수 있도록 Testcontainer dependency를 추가하였습니다.

4. 원활한 integration 테스트 수행을 위한 테스트 프로필 추가
  - 테스트 시 사용될 "test" 프로필을 추가하였습니다.
  - 테스트 프로필 사용 시, jasypt encryptor password를 "dummy"로 로드되도록 하였습니다.
  - 테스트 프로필 사용 시, oauth client id, secret 등 ENC 값들을 "dummy"로 로드되도록 하였습니다.
  - 이제 integration 테스트를 ActiveProfile("test")로 지정하면, ApplicationContext 로드 시 발생할 수 있는 jasypt 모듈이나 oauth 모듈의 bean 초기화가 되지 않는 문제는 나타나지 않게 되었습니다.

5. Testcontainer 도입 관련 변경 사항
  - test-ci.sh, test-env.sh 삭제
  - workflow에서 해당 sh 사용하는 부분 삭제
